### PR TITLE
fix nproc not found on Max OSX, use built-in tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,13 @@
 # MODE = release | debug (default: release)
 
 # Management PC specific settings
+OS_NAME := $(shell uname -s)
+ifeq ($(OS_NAME),Darwin) # for OS X, use build in tools
+CORE_NUM := $(shell sysctl -n hw.ncpu)
+else # Linux and other
 CORE_NUM := $(shell nproc)
+endif
+
 ifneq ($(CORE_SPEED_KHz), )
 CFLAGS += -DCORE_NUM=${CORE_NUM}
 else

--- a/scripts/config
+++ b/scripts/config
@@ -1,6 +1,12 @@
 unm=$(uname -n);
 
-num_cores=$(nproc);
+os_name=$(uname -s);
+if [ "$os_name" = "Darwin" ];
+then
+	num_cores=$(sysctl -n hw.ncpu);
+else
+	num_cores=$(nproc);
+fi;
 
 echo "## Use $num_cores as the number of cores."
 echo "## If not correct, change it in scripts/config";


### PR DESCRIPTION
Use Mac OS X built-in command `sysctl -n cpu` to get logical CPU numbers.
For those who did not have nproc on their system.
