### PR TITLE
Improve correctness of CAS_PTR

### DIFF
--- a/include/atomics.h
+++ b/include/atomics.h
@@ -12,8 +12,8 @@
 #define CAS_PTR(a, b, c)                                                \
     __extension__({                                                     \
         typeof(*a) _old = b, _new = c;                                  \
-        __atomic_compare_exchange(a, &_old, &_new, 1, __ATOMIC_RELAXED, \
-                                  __ATOMIC_RELAXED);                    \
+        __atomic_compare_exchange(a, &_old, &_new, 1, __ATOMIC_SEQ_CST, \
+                                  __ATOMIC_SEQ_CST);                    \
         _old;                                                           \
     })
 #define CAS_U8(a, b, c) CAS_PTR(a, b, c)

--- a/include/atomics.h
+++ b/include/atomics.h
@@ -12,7 +12,7 @@
 #define CAS_PTR(a, b, c)                                                \
     __extension__({                                                     \
         typeof(*a) _old = b, _new = c;                                  \
-        __atomic_compare_exchange(a, &_old, &_new, 1, __ATOMIC_SEQ_CST, \
+        __atomic_compare_exchange(a, &_old, &_new, 0, __ATOMIC_SEQ_CST, \
                                   __ATOMIC_SEQ_CST);                    \
         _old;                                                           \
     })


### PR DESCRIPTION
This commit have two major changes.

The first change is to set the weak argument in __atomic_compare_exchange to 0, which means that the CAS_PTR can't fail if destination value is equal to expected value.
The implementation of CAS_PTR returns the second variable of __atomic_compare_exchange to its caller, which is expected value if comparison is equal, or destination variable's value if the comparison is unequal. However, the caller can't determine whether the CAS_PTR successes or not if CAS_PTR could fail even if the comparison is equal.

The second change is to set the memory order of CAS_PTR to sequential consistency. The relaxed order will blunder in some situation. For example, if a new node is going to be inserted in linked list:
```
1   new_elem->next = right;
2   if (CAS_PTR(&(left->next), right, new_elem) == right) {
3       FAI_U32(&(the_list->size));
4       return true;
5   }
```
On relaxed order, line 1 may still in write buffer after line 2 finishing, which is invisible to other threads.
There may still have room for improvement on relaxing memory order in
this case, I haven't considered other memory orders carefully.