### PR TITLE
Add RISC-V support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The `concurrent-ll` package contains the skeleton code for implementing and
 evaluating two concurrent linked lists: a lock-free and a lock-based.
-The implementations should work on any Linux-based `x86`/`x86_64`/`Arm64`
+The implementations should work on any Linux-based `x86`/`x86_64`/`Arm64`/`riscv32`/`riscv64`
 environments.
 
 Both lists are sorted and provide three main operations: 


### PR DESCRIPTION
Add a getticks() function for RISC-V platforms that reads the time (and timeh for RV32) U-mode CSR, which counts system wall-clock.